### PR TITLE
Critical config fix due to invalid work of substr and mb_substr PHP functions

### DIFF
--- a/lib/Aspose/Imaging/Configuration.php
+++ b/lib/Aspose/Imaging/Configuration.php
@@ -188,7 +188,7 @@ class Configuration
      */
     public function setBaseUrl($baseUrl)
     {
-        if (!(substr($this->baseUrl, -1, 1) === "/"))
+        if ($baseUrl[strlen($baseUrl) - 1] !== "/")
         {
             $baseUrl = $baseUrl . "/";
         }


### PR DESCRIPTION
Both built-in functions don't recognize '/' character at all.